### PR TITLE
Add AWS CFN adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ These are connectors created and maintained by the community.  Not endorsed or s
 
 Name of Connector     | Data Source   |  Author   |   Source Code    |  Hosted URL
 -------- |  -------- |  -------- |  --------  | ---------
+AWS CloudWatch | [CloudWatch](https://aws.amazon.com/cloudwatch/) | David F. Severski|  [Tableau WDC for CloudWatch](https://github.com/davidski/tableau-wdc-cloudwatch)  |  N/A
 Elastic Search | [Elastic Search](https://www.elastic.co/products/elasticsearch) | Adam Lacey  |  [mradamlacey](https://github.com/mradamlacey/elasticsearch-tableau-connector)  |  N/A
 Fitbit | [Fitbit.com](https://www.fitbit.com/) | Craig Bloodworth  |  N/A  |  [Fitbit WDC](http://data.theinformationlab.co.uk/fitbit.html)
 Flickr | [Flickr](https://www.flickr.com/services/api/) | [Zeki Melek](https://github.com/melekzek)  |  [tableau-wdc-flickr](https://github.com/melekzek/tableau-wdc-flickr)  |  N/A


### PR DESCRIPTION
This adds a pointer to a functional AWS CloudWatch WDC.