### PR TITLE
Adding EIA WDC

### DIFF
--- a/docs/community/community_connectors.json
+++ b/docs/community/community_connectors.json
@@ -251,5 +251,23 @@
         "tags": ["v_2.0"],
         "description": "",
         "source_code": "https://github.com/austinderrick/fred_wdc_20"
+    },
+    {
+        "name": "U.S. Energy Information Administration Data",
+        "url": "http://wdc.poc.interworks.com/eia/",
+        "author": "Derrick Austin",
+        "github_username": "austinderrick",
+        "tags": ["v_1.1"],
+        "description": "",
+        "source_code": ""
+    },
+    {
+        "name": "U.S. Energy Information Administration Data",
+        "url": "http://wdc.poc.interworks.com/eia_20/",
+        "author": "Derrick Austin",
+        "github_username": "austinderrick",
+        "tags": ["v_2.0"],
+        "description": "",
+        "source_code": "https://github.com/austinderrick/eia_wdc_20"
     }
 ]


### PR DESCRIPTION
Adds a WDC Connector to the U.S. Energy Information Administration.