### PR TITLE
Add podcast metdata WDC to the community list

### DIFF
--- a/docs/community/community_connectors.json
+++ b/docs/community/community_connectors.json
@@ -154,6 +154,15 @@
         "source_code": ""
     },
     {
+        "name": "Podcast Metadata",
+        "url": "https://podcast-wdc.herokuapp.com/",
+        "author": "Eric Peterson",
+        "github_username": "iamEAP",
+        "tags": ["v_2.0"],
+        "description": "Parses podcast channel and episode metadata from feed URLs.",
+        "source_code": "https://github.com/iamEAP/podcast-wdc"
+    },
+    {
         "name": "Quandl",
         "url": "http://data.theinformationlab.co.uk/quandl.html",
         "author": "Craig Bloodworth",


### PR DESCRIPTION
First POC built [on top](https://github.com/iamEAP/podcast-wdc/blob/master/src/main.js#L15) of the [web data connector wrapper](https://tableau-mkt.github.io/wdcw).  