### PR TITLE
Added abortForAuth simulator handling

### DIFF
--- a/Simulator/wdc-simulator.js
+++ b/Simulator/wdc-simulator.js
@@ -480,7 +480,10 @@
       var inDataGatherPhase = wdcCommandSim.state.currentPhase === WdcCommandSimulator.Phase.GATHER_DATA;
 
       var isWDCUrlEmpty = (this.state.wdcUrl === '');
-     
+
+      var startAuthPhase = this.startPhase.bind(this, WdcCommandSimulator.Phase.AUTH);
+
+      var startInteractivePhase = this.startPhase.bind(this, WdcCommandSimulator.Phase.INTERACTIVE);
       return (
         DOM.div({ className: 'simulator-app' },
           DOM.div({ className: 'navbar navbar-default' },
@@ -499,8 +502,8 @@
             Col.element({ md: 6, className: 'run-connector' },
               PhaseTitle.element({ title: 'Run Connector', isInProgress: interactiveStateInProgress }),
               DOM.div({},
-                Button.element({ onClick: this.startInteractivePhase, bsStyle: 'success', disabled: isInProgress || isWDCUrlEmpty }, 'Start Interactive Phase'),
-                Button.element({ onClick: this.startAuthPhase, bsStyle: 'success', style: { marginLeft: '4px' }, disabled: isInProgress || isWDCUrlEmpty }, 'Start Auth Phase'),
+                Button.element({ onClick: startInteractivePhase, bsStyle: 'success', disabled: isInProgress || isWDCUrlEmpty }, 'Start Interactive Phase'),
+                Button.element({ onClick: startAuthPhase, bsStyle: 'success', style: { marginLeft: '4px' }, disabled: isInProgress || isWDCUrlEmpty }, 'Start Auth Phase'),
                 interactiveStateInProgress ? Button.element({ onClick: this.cancelCurrentPhase,
                                                               style: { marginLeft: '4px' } }, 'Abort') : null
               ),
@@ -665,28 +668,19 @@
       });
     },
 
-    startInteractivePhase: function() {       
-      this.setState({ wdcUrlDisabled: true });
+    startPhase: function(phaseName, e) {
+      this.setState({ wdcUrlDisabled: true});
 
       var wdcSim = this.state.wdcCommandSimulator;
 
       wdcSim.resetTables();
-      wdcSim.setInteractivePhase();
-      wdcSim.setInProgress();
-
-      this.closeSimulatorWindowAndGatherDataFrame(function() {
-        var openWindow = window.open(this.state.wdcUrl, 'simulator', SimulatorApp.WINDOW_PROPS);
-        this.setState({ openWindow: openWindow });
-      });
-    },
-
-    startAuthPhase: function() {
-      this.setState({ wdcUrlDisabled: true });
-
-      var wdcSim = this.state.wdcCommandSimulator;
-
-      wdcSim.resetTables();
-      wdcSim.setAuthPhase();
+      console.log(phaseName)
+      if(phaseName === WdcCommandSimulator.Phase.INTERACTIVE) {
+        wdcSim.setInteractivePhase();
+      } 
+      if(phaseName === WdcCommandSimulator.Phase.AUTH) {
+        wdcSim.setAuthPhase();
+      }
       wdcSim.setInProgress();
 
       this.closeSimulatorWindowAndGatherDataFrame(function() {

--- a/docs/community/community_connectors.json
+++ b/docs/community/community_connectors.json
@@ -91,6 +91,15 @@
         "source_code": ""
     },
     {
+        "name": "League of Legends Match Data",
+        "url": "https://jimmy-jia.github.io/LoL-Match-Data-WDC/",
+        "author": "Jimmy Jia",
+        "github_username": "jimmy-jia",
+        "tags": ["v_2.0"],
+        "description": "LoL Match Data Connector that retrieves recent matches for up to 5 players",
+        "source_code": "https://github.com/jimmy-jia/LoL-Match-Data-WDC"
+    },
+    {
         "name": "Mad Money Scraper Dev Sample",
         "url": "https://tableau.github.io/webdataconnector/ExamplesV2/MadMoneyScraper.html",
         "author": "Tableau",


### PR DESCRIPTION
Added handling of abortForAuth for the simulator.

On abortForAuth call, the current operation is cancelled and the connector window is closed.
The user is then displayed a toastr message, prompting them to click the newly added Auth Launch button.