### PR TITLE
Removed column role attribute from the earthquake examples' lat/long …

### DIFF
--- a/Examples/js/earthquakeMultitable.js
+++ b/Examples/js/earthquakeMultitable.js
@@ -19,14 +19,10 @@
         }, {
             id: "lat",
             alias: "latitude",
-            columnRole: "dimension",
-            // Do not aggregate values as measures in Tableau--makes it easier to add to a map 
             dataType: tableau.dataTypeEnum.float
         }, {
             id: "lon",
             alias: "longitude",
-            columnRole: "dimension",
-            // Do not aggregate values as measures in Tableau--makes it easier to add to a map 
             dataType: tableau.dataTypeEnum.float
         }];
 

--- a/Examples/js/earthquakeUSGS.js
+++ b/Examples/js/earthquakeUSGS.js
@@ -18,14 +18,10 @@
         }, {
             id: "lat",
             alias: "latitude",
-            columnRole: "dimension",
-            // Do not aggregate values as measures in Tableau--makes it easier to add to a map 
             dataType: tableau.dataTypeEnum.float
         }, {
             id: "lon",
             alias: "longitude",
-            columnRole: "dimension",
-            // Do not aggregate values as measures in Tableau--makes it easier to add to a map 
             dataType: tableau.dataTypeEnum.float
         }];
 


### PR DESCRIPTION
…columns.

Lat/long should be measures to stay consistent with Tableau