### PR TITLE
Updating sample connector HTML files to have META elements correctly nested under HEAD

### DIFF
--- a/Examples/html/IncrementalRefreshConnector.html
+++ b/Examples/html/IncrementalRefreshConnector.html
@@ -1,8 +1,8 @@
 <html>
-<meta http-equiv="Cache-Control" content="no-cache" />
-<meta http-equiv="Cache-Control" content="no-store" />
 <head>
 <title>Incremental Update Example</title>
+<meta http-equiv="Cache-Control" content="no-cache" />
+<meta http-equiv="Cache-Control" content="no-store" />
 <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js" type="text/javascript"></script>
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js" integrity="sha384-0mSbJDEHialfmuBBQP6A4Qrprq5OVfW37PRR3j5ELqxss1yVqOtnepnHVP9aJ7xS" crossorigin="anonymous"></script>

--- a/Examples/html/MadMoneyScraper.html
+++ b/Examples/html/MadMoneyScraper.html
@@ -1,8 +1,8 @@
 <html>
-<meta http-equiv="Cache-Control" content="no-cache" />
-<meta http-equiv="Cache-Control" content="no-store" />
 <head>
 <title>Mad Money Scraper</title>
+<meta http-equiv="Cache-Control" content="no-cache" />
+<meta http-equiv="Cache-Control" content="no-store" />
 <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js" type="text/javascript"></script>
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js" integrity="sha384-0mSbJDEHialfmuBBQP6A4Qrprq5OVfW37PRR3j5ELqxss1yVqOtnepnHVP9aJ7xS" crossorigin="anonymous"></script>

--- a/Examples/html/StockQuoteConnector_promises.html
+++ b/Examples/html/StockQuoteConnector_promises.html
@@ -1,8 +1,8 @@
 <html>
-<meta http-equiv="Cache-Control" content="no-cache" />
-<meta http-equiv="Cache-Control" content="no-store" />
 <head>
 <title>Stock Quote Connector</title>
+<meta http-equiv="Cache-Control" content="no-cache" />
+<meta http-equiv="Cache-Control" content="no-store" />
 <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js" type="text/javascript"></script>
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js" integrity="sha384-0mSbJDEHialfmuBBQP6A4Qrprq5OVfW37PRR3j5ELqxss1yVqOtnepnHVP9aJ7xS" crossorigin="anonymous"></script>


### PR DESCRIPTION
Three of the example connector HTML files had the `META` Cache-Control elements incorrectly nested under the root `HTML` element.  This could cause these examples to be cached by the browser, leading to user confusion when making edits.

As per the [HTML5 spec](https://www.w3.org/TR/2016/REC-html51-20161101/document-metadata.html#the-meta-elementl), these should be placed within the `HEAD` element.

This PR updates IncrementalRefreshConnector.html, MadMoneyScraper.html, and StockQuoteConnector_promises.html to move the `META` elements to the correct location, nested within `HEAD`.

I've placed the `META` elements beneath the `TITLE` element in order to stay consistent with the arrangement in the other examples (earthquakeUSGS.html, etc).