### PR TITLE
Fix the description of Facebook Insights Connector

### DIFF
--- a/community/community_connectors.json
+++ b/community/community_connectors.json
@@ -553,7 +553,7 @@
         "author": "kaizenplatform",
         "github_username": "kaizenplatform",
         "tags": ["v0.1.1"],
-        "description": "Connector to allow connections to the USPTO PatentsWeb API",
+        "description": "Tableau WDC for Insights of Facebook Marketing API",
         "source_code": "https://github.com/kaizenplatform/FacebookInsightsConnector"
     }
 ]


### PR DESCRIPTION
I forgot to update the description after copying information from the other connector to make it the placeholder. Could you merge this to correct the description?