### PR TITLE
Add parkrun connector

### DIFF
--- a/community/community_connectors.json
+++ b/community/community_connectors.json
@@ -180,6 +180,11 @@
         "source_code": "https://github.com/jdomingu/osm-features-wdc"
     },
     {
+        "name": "parkrun",
+        "url": "https://parkrun-webdataconnector.now.sh",
+        "author": "Mark Woodbridge"
+    },
+    {
         "name": "ParseHub",
         "url": "http://data.theinformationlab.co.uk/parsehub.html",
         "author": "Craig Bloodworth",


### PR DESCRIPTION
This is a Web Data Connector for [parkrun](http://www.parkrun.org.uk). Providing your [runner ID](https://support.parkrun.com/hc/en-us/articles/200566243-What-is-my-athlete-parkrun-ID-number-) is sufficient for Tableau to retrieve your run dates, venues and times. Please see [My parkruns](https://public.tableau.com/profile/mark8697#!/vizhome/Myparkruns/Sheet1) on Tableau Public for an example workbook.