### PR TITLE
Update auth types to reflect actual values

### DIFF
--- a/docs/wdc_authentication.md
+++ b/docs/wdc_authentication.md
@@ -15,9 +15,9 @@ Types of authentication {#auth-types}
 -------------------------------------
 There are three types of authentication recognized by the WDC API:
 
-- `None` - for connectors that do not have any authentication needs
-- `Basic` - for connectors that need username/password authentication.
-- `Custom` - for any other type of authentication or authorization (OAuth, as an example).
+- `none` - for connectors that do not have any authentication needs
+- `basic` - for connectors that need username/password authentication.
+- `custom` - for any other type of authentication or authorization (OAuth, as an example).
 
 A connector should set its auth type in a custom init method.  For example: 
 


### PR DESCRIPTION
I noticed that the actual variables used are lowercase (e.g. tableau.authTypeEnum.custom instead of tableau.authTypeEnum.Custom), so I think the docs should reflect that.