### PR TITLE
Updated the connector URL to point to home page

### DIFF
--- a/community/community_connectors.json
+++ b/community/community_connectors.json
@@ -225,7 +225,7 @@
     },
     {
         "name": "Rally CA Agile",
-        "url": "https://k504866430.github.io/rally-tableau/wdc",
+        "url": "https://k504866430.github.io/rally-tableau",
         "author": "Harsh Agrawal",
         "github_username": "",
         "tags": ["v_1.0"],


### PR DESCRIPTION
The connector URL was pointing to actual connector instead of the description page