### PR TITLE
Add call to initCallback to init function.

### DIFF
--- a/docs/wdc_authentication.md
+++ b/docs/wdc_authentication.md
@@ -28,6 +28,7 @@ For example:
   // Init function for connector, called during every phase
   myConnector.init = function(initCallback) {
       tableau.authType = tableau.authTypeEnum.custom;
+      initCallback();
   }
 ```
 


### PR DESCRIPTION
This caused an issue for me since i just copied this little sample of code.
Without calling the init callback, it failed with no indication of why.
Hopefully this will help others avoid that.