### PR TITLE
Update wdc_tutorial.md to add url to the table

### DIFF
--- a/docs/wdc_tutorial.md
+++ b/docs/wdc_tutorial.md
@@ -251,6 +251,7 @@ myConnector.getData = function(table, doneCallback) {
                 "id": feat[i].id,
                 "mag": feat[i].properties.mag,
                 "title": feat[i].properties.title,
+                "url" : feat[i].properties.url,
                 "lon": feat[i].geometry.coordinates[0],
                 "lat": feat[i].geometry.coordinates[1]
             });


### PR DESCRIPTION
The url column is missing getData().
It's supposed to be there as evidenced by the entry in getSchema() and the screenshot that shows the url in the table.
This change adds it.