### PR TITLE
Doc updates to dev branch - added upgrade from v1 and server topic

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@ title: Tableau Web Data Connector
 email: jdominguez@tableau.com
 description: Connect to your web data from Tableau.
 baseurl: "/webdataconnector"
-permalinks: pretty
+# permalinks: pretty
 defaults:
   -
     scope:
@@ -14,6 +14,9 @@ defaults:
 # Build settings
 markdown: kramdown
 highlighter: rouge
+
+kramdown:
+    toc_levels: 1..3
 
 # Exclude
 exclude: ['node_modules']

--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@ title: Tableau Web Data Connector
 email: jdominguez@tableau.com
 description: Connect to your web data from Tableau.
 baseurl: "/webdataconnector"
-# permalinks: pretty
+# permalink: pretty
 defaults:
   -
     scope:

--- a/_includes/docs_menu.html
+++ b/_includes/docs_menu.html
@@ -63,7 +63,7 @@
             <a href="{{ site.baseurl }}/docs/wdc_faq">FAQ</a>
         </li>
 		<li>
-		    <a href="{{ site.baseurl }}/docs/wdc_upgrade">Upgrading to WDC Version 2</a>
+		    <a href="{{ site.baseurl }}/docs/wdc_upgrade">Upgrading from WDC Version 1.x</a>
 		</li>
     </ul>
 </div>

--- a/_includes/docs_menu.html
+++ b/_includes/docs_menu.html
@@ -62,5 +62,8 @@
         <li>
             <a href="{{ site.baseurl }}/docs/wdc_faq">FAQ</a>
         </li>
+		<li>
+		    <a href="{{ site.baseurl }}/docs/wdc_upgrade">Upgrading to WDC Version 2</a>
+		</li>
     </ul>
 </div>

--- a/_includes/docs_menu.html
+++ b/_includes/docs_menu.html
@@ -9,7 +9,10 @@
             <a href="{{ site.baseurl }}/docs/wdc_tutorial">Tutorial</a>
         </li>
         <li>
-            <a href="{{ site.baseurl }}/docs/wdc_use_in_tableau">Use a WDC in Tableau</a>
+            <a href="{{ site.baseurl }}/docs/wdc_use_in_tableau">Use a WDC in Tableau Desktop</a>
+        </li>
+		<li>
+            <a href="{{ site.baseurl }}/docs/wdc_use_in_server">Use a WDC in Tableau Server</a>
         </li>
 
         <li class="nav-header">Basic Concepts</li>

--- a/_layouts/news.html
+++ b/_layouts/news.html
@@ -15,7 +15,7 @@ layout: news
 		<h3>WDC News</h3>
 		    <ul class=posts >
 			  {% for post in site.posts %}
-	          <li><a href="#{{ post.id }}" title="{{ post.title }}">{{ post.title }}</a> &nbsp;  <span style="font-size:80%;">({{ post.date | date_to_string }})</span></li>
+	          <li><a href="#{{ post.id }}" >{{ post.title }}</a> &nbsp;  <span style="font-size:80%;">({{ post.date | date_to_string }})</span></li>
 	         {% endfor %}
 		    </ul>
 			<hr/>

--- a/_layouts/news.html
+++ b/_layouts/news.html
@@ -11,10 +11,19 @@ layout: news
 <body>
     <div class="container">
         {% include header.html %}
+        <div>		
+		<h3>WDC News</h3>
+		    <ul class=posts >
+			  {% for post in site.posts %}
+	          <li><a href="#{{ post.id }}" title="{{ post.title }}">{{ post.title }}</a> &nbsp;  <span style="font-size:80%;">({{ post.date | date_to_string }})</span></li>
+	         {% endfor %}
+		    </ul>
+			<hr/>
+	   </div>
         <ul class="blogul">
             {% for post in site.posts %}
             <div>
-                <h1>{{ post.title }}</h1>
+                <h1 id="{{post.id}}">{{ post.title }} </a></h1>
                 <hr>
                 <p><span class="glyphicon glyphicon-time"></span> Posted on {{ post.date | date: "%-d %B %Y" }}</p>
                 <hr>

--- a/docs/api_ref.md
+++ b/docs/api_ref.md
@@ -517,7 +517,7 @@ title: WDC API Reference
                         <div class="tsd-signature tsd-kind-icon">id: string</div>
                         <div class="tsd-comment tsd-typography">
                             <div class="lead">
-                                <p>The id of this column. Column ids must be unique within a table.</p>
+                                <p>The id of this column. Column ids must be unique within a table. The id can only contain alphanumeric (a-z, A-Z, 0-9) and underscore characters (<code>_</code>). The id must match the regular expression: <code>"^[a-zA-Z0-9_]\*$"</code>.</p>
                             </div>
                         </div>
                     </section>
@@ -818,7 +818,7 @@ var standardConnection = {
                         <div class="tsd-signature tsd-kind-icon">id: string</div>
                         <div class="tsd-comment tsd-typography">
                             <div class="lead">
-                                <p>A unique id for this particular table.</p>
+                                <p>A unique id for this particular table. The id can only contain alphanumeric (a-z, A-Z, 0-9) and underscore characters (<code>_</code>). The id must match the regular expression: <code>"^[a-zA-Z0-9_]\*$"</code>.</p>
                             </div>
                         </div>
                     </section>

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,10 +8,19 @@ with JavaScript code that connects to web data (for example, by means of a REST 
 and passes the data to Tableau.
 
 <div class="alert alert-info">
-    <b>Note:</b> This site is for version 2 of the WDC, which is compatible only with Tableau 10.0 and later. For
+    <b>Note:</b> This site is for version 2.x of the WDC, which is compatible only with Tableau 10.0 and later. For
     information about version 1 of the WDC for use with earlier versions of Tableau, see the archived <a href="http://onlinehelp.tableau.com/v9.3/api/wdc/en-us/help.htm" style="text-decoration:underline;">documentation</a>
-    and <a href="https://github.com/tableau/webdataconnector/releases/tag/v1.1.0" style="text-decoration:underline;">simulator</a>.
+    and <a href="https://github.com/tableau/webdataconnector/releases/tag/v1.1.0" style="text-decoration:underline;">simulator</a>.  
 </div>
+
+-----
+
+**Upgrading from WDC version 1.x**
+ 
+If you have connectors that were created using WDC version 1.x, those connectors will continue to work in future versions of Tableau. However, if you want to update the connectors to use the features available in version 2.x of the WDC, you will need to update the connector to use the new API. For information about updating your connectors, see [Upgrading from WDC Version 1.x]({{ site.baseurl }}\docs\wdc_upgrade).
+
+
+-----
 
 This section will guide you through the process of setting up your development environment and running the sample WDCs
 in the simulator.

--- a/docs/wdc_tutorial.md
+++ b/docs/wdc_tutorial.md
@@ -67,7 +67,7 @@ following between the `head` tags:
 
 * The `meta` tag prevents your browser from caching the page.
 * The `bootstrap.min.css` and `bootstrap.min.js` files are used to simplify styling and formatting.
-* The `jquery.min.js` file will be used as a helper library by our connector. (For example, the connector uses jquery to
+* The `jquery.min.js` file will be used as a helper library by our connector. (For example, the connector uses jQuery to
   get JSON data.)
 * The `tableauwdc-2.3.latest.js` file is the main library for the WDC API.
 * The `earthquakeWDC.js` file is the (not yet created) JavaScript code for our connector.
@@ -191,8 +191,8 @@ If all goes well, you should see `Hello WDC!` in your browser's console.
 So the connector is working now--sort of. Before you can download data and pass it to Tableau, you need to define how
 you want to map the data to one or more or tables. This mapping of data is done in the schema.
 
-To decide what data you want to map in the schema, you can take a look at a description of the JSON data source
-[here](http://earthquake.usgs.gov/earthquakes/feed/v1.0/geojson.php). Rather than map all the data available from the
+To decide what data you want to map in the schema, you can take a look at the USGS description of the JSON data source:
+[GeoJSON Summary Format](http://earthquake.usgs.gov/earthquakes/feed/v1.0/geojson.php){:target="_blank"}. Rather than map all the data available from the
 data source, this example has selected a focused subset.
 
 When you're done looking at the summary of the JSON data source, copy the following code into the `earthquakeWDC.js`
@@ -232,8 +232,8 @@ Here's what's going on in the code:
 * The `cols` variable contains an array of JavaScript objects, where each object defines a single column in our table.
   In this example, there are columns for magnitude, title, and location. Note that for each column you can
   specify additional options. For example, the alias defines a friendly name that can appear in Tableau and the
-  columnRole determines whether a field is a measure or a dimension. For more options, see [the API reference]({{
-      site.baseurl }}/docs/api_ref.html#webdataconnectorapi.columninfo).
+  columnRole determines whether a field is a measure or a dimension. The `id` can only contain alphanumeric values (a-z, A-Z, 0-9) and underscore characters (`_`). The identifiers cannot contain spaces, hyphens, or special characters. For more options, see [the API reference]({{
+      site.baseurl }}/docs/api_ref.html#webdataconnectorapi.columninfo){:target="_blank"}.
 * The `tableSchema` variable defines the schema for a single table and contains a JavaScript object. Here, the value of
   the `columns` property is set to the `cols` array defined earlier.
 * The `schemaCallback` gets called when the schema is defined. The `schemaCallback` takes an array of table objects. In

--- a/docs/wdc_upgrade.md
+++ b/docs/wdc_upgrade.md
@@ -44,7 +44,7 @@ To support the new features, changes have been made to the API. For example, to 
 
 ### Changes to column and table identifiers
 
-In WDC version 2.x, the column and table identifiers (`columnId` and `tableId`) cannot contain spaces. In version 1..x, the string values containing spaces were allowed to pass through. 
+In WDC version 2.x, the column and table identifiers (`columnId` and `tableId`) can only contain alphanumeric (a-z, A-Z, 0-9) and underscore characters (`_`). The identifiers must match the regular expression: `^[a-zA-Z0-9_]*$`. The identifiers cannot contain spaces, hyphens, or special characters. In WDC version 1.x, the string values containing spaces were allowed to pass through. 
 
 
 ### Test your connector with the WDC simulator

--- a/docs/wdc_upgrade.md
+++ b/docs/wdc_upgrade.md
@@ -1,0 +1,53 @@
+---
+title: Upgrading from WDC Version 1.x 
+layout: docs
+---
+
+If you have built connectors using WDC version 1.x you can continue to use those connectors in future versions of Tableau. However, if you link a version 1.x connector to version 2.x of the Tableau WDC library, the connector will not work unless you also update the connector to use code changes introduced in version 2.x of the API.
+
+**In this section**
+* TOC
+{:toc}
+
+
+### Why should you upgrade?
+
+You should considering upgrading your connectors to version 2.x to have access to all the great new features that have been introduced for WDC in Tableau 10.0 and later. You might want to keep your version 1.x connectors if you need to support earlier versions of Tableau.   
+
+In version 2.x you can:
+
+- Include multiple tables of data.
+- Signal that you are done gathering data with a single callback, and you can add data that you gather directly to a table object created by Tableau. Previously, there was no way to signal that you were done gathering data. As a result, the WDC API repeatedly ran your `getTableData` function so that you could pass data to Tableau through a callback parameter. 
+- Use the locale API to get the language currently set by the user in Tableau. 
+- Specify how you want to join tables (standard connections) in Tableau Desktop. 
+- Use join filtering to filter the data from one table based on the data from another. 
+- Connect directly to spatial data. Using the new geometry value in the `tableau.dataType` enum, you can send GeoJSON objects directly back to Tableau.
+
+### Lifecycle and phase differences between version 1.x and version 2.x
+
+To support the new features, changes have been made to the API. For example, to support multiple tables, there is now a `getSchema()` function that has a callback function for reporting the tables contained in the WDC. The `getTableData()` function was changed to `getData()` and it now takes a table object as a parameter. Review the following list and the samples to better understand the changes. 
+
+**In version 1.x:**
+
+1. A connector loads and runs its interactive phase, then calls `tableau.submit()`.
+2. In the data gathering phase, Tableau calls `connector.getColumnHeaders()`, which defines the schema for a single table. The `getColumnHeaders()` function finishes by calling a predefined callback.
+3. Tableau calls `connector.getTableData()`, which passes data to Tableau by means of a parameter on the predefined `tableau.dataCallback()` function.
+4. Step 3 is repeated until `tableau.dataCallback()` passes a flag to Tableau to signal that there is no more data.
+
+**In version 2.x:**
+
+1. A connector loads and runs its interactive phase, then calls `tableau.submit()`.
+2. In the data gathering phase, Tableau calls `connector.getSchema()`, which defines the schema for one or more tables. The connector calls a predefined callback to signal that it is done defining the table schema.
+3. Tableau calls `connector.getData()` with a table object parameter and a callback parameter. The `getData()` function appends data to the table object using the object's built-in `table.appendRows()` function. The `getData()` function is called once for each table defined in the schema. 
+4. When the `getData()` function is done gathering data, it calls the `doneCallback()` that it was passed as a parameter.
+
+
+### Changes to column and table identifiers
+
+In WDC version 2.x, the column and table identifiers (`columnId` and `tableId`) cannot contain spaces. In version 1..x, the string values containing spaces were allowed to pass through. 
+
+
+### Test your connector with the WDC simulator
+
+As always, it is good practice to test your connector in the WDC version 2.x simulator to make sure you are getting the data that you expect. See [Debugging in the Simulator and Tableau]({{ site.baseurl }}\docs\wdc_debugging).
+

--- a/docs/wdc_use_in_server.md
+++ b/docs/wdc_use_in_server.md
@@ -1,0 +1,17 @@
+---
+title: Use a WDC in Tableau Server
+layout: docs
+---
+
+You can use your web data connector (WDC) on Tableau Server as you would any other data source. You can publish the web data connector as a data source, or you can publish a workbook that embeds your connector as the data source.  
+
+When you use a web data connector, Tableau creates an extract of the data. You can refresh the extract in Tableau Desktop. However, to be able to refresh the extract on Tableau Server, there are a couple of other considerations. 
+
+- You need to ensure that your web data connector is added to the safe list. Because a WDC contains JavaScript and typically connects to other sites, you need to work with the Tableau Server administrator to test and verify the connector is safe to use. 
+
+- If your web data connector requires authentication, you need to embed the credentials when you publish the data source or workbook. This is because the refresh can occur on a schedule or in some other background context, and the server cannot prompt for credentials.
+
+- For security, consider using HTTPS protocol for the connector and all external libraries that the your web data connector uses.     
+
+For more information, see [Web Data Connectors in Tableau Server](http://onlinehelp.tableau.com/current/server/en-us/datasource_wdc.htm){:target="_blank"} and [Testing and Vetting Web Data Connectors](http://onlinehelp.tableau.com/current/server/en-us/datasource_wdc_vetting.htm){:target="_blank"} in the Tableau Server Help. 
+

--- a/docs/wdc_use_in_tableau.md
+++ b/docs/wdc_use_in_tableau.md
@@ -2,7 +2,6 @@
 title: Use a WDC in Tableau Desktop
 layout: docs
 ---
-
 To use a WDC in Tableau Desktop, complete the following steps:
 
 1. On the start page, in the **Connect** pane, click **More Servers... > Web Data Connector**.
@@ -14,8 +13,10 @@ To use a WDC in Tableau Desktop, complete the following steps:
    ![]({{ site.baseurl }}/assets/wdc_desktop_enter_url.png)
 
    **Important**: Make sure that you enter the URL of a WDC, and not the URL of the data that you're trying to connect
-   to. For example, if you want to connect to Facebook data, you might enter `www.example.com/myFacebookWDC.html`.
+   to. For example, if you want to connect to FaceBook data, you might enter `www.example.com/myFacebookWDC.html`.
 
 1. Tableau loads the WDC page where you can enter any input required by your WDC.
 
 1. Tableau calls your WDC code, downloads data, and displays it in the **Data Source** pane.
+
+For more information about using a WDC in Tableau Desktop, see [Web Data Connector](https://onlinehelp.tableau.com/current/pro/desktop/en-us/help.html#examples_web_data_connector.html){:target="_blank"}.


### PR DESCRIPTION
I also added the regex that we use for `tableinfoId` and `columnId`
I commented out the `permalink: pretty` in `_config.yml`, as permalink changes the behavior slightly.  Instead of creating `/docs/somefile.html` as output, the `permalink: pretty` setting creates `/docs/somefile/index.html`  - By commenting out the setting, it keeps (or should keep) the current behavior where we don't need to provide file name extension in links.  `permalinks` is a NOP.  Adding this note in case that is not the case. 