### PR TITLE
Dockerize simulator and example connectors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:10.14-alpine
+
+COPY . /webdataconnector
+WORKDIR /webdataconnector
+
+RUN apk --no-cache add ca-certificates git
+
+RUN npm install --production
+
+CMD ["npm", "start"]


### PR DESCRIPTION
This should simplify setup of the local development environment
while building tableau WDC.

Instead of cloning and building it locally, with this simple Dockerfile
we can bootstrap everything required in just two steps:

```
docker build . -t webdataconnector
docker run -d -p 9999:8888 webdataconnector:latest
```

And access simulator at:
`http://localhost:9999/Simulator/index.html`

or examples at:
`http://localhost:9999/Examples/`

Would be also recommended that Tableau builds and publishes this
container in one of the public docker reposiotores (i.e. DockerHub).