### PR TITLE
Update api_ref.md

### DIFF
--- a/docs/api_ref.md
+++ b/docs/api_ref.md
@@ -1666,7 +1666,7 @@ if (row_index % 100 === 0) {
                                 <li class="tsd-kind-method tsd-parent-kind-interface"><span class="tsd-kind-icon">Method</span></li>
                             </ul>
                         </div>
-                        <p>Generated using <a href="http://typedoc.io" target="_blank">TypeDoc</a></p>
+                        <p>Generated using <a href="https://typedoc.org" target="_blank">TypeDoc</a></p>
                     </div>
                 </section>
             </section>


### PR DESCRIPTION
Since the API docs were generated it looks like TypeDoc lost/changed their domain. This keeps the attribute link at the bottom of the API page but corrects the URL to point to TypeDoc's current (and hopefully permanent?) domain.