### PR TITLE
Add NoteTab connector

### DIFF
--- a/community/community_connectors.json
+++ b/community/community_connectors.json
@@ -386,6 +386,15 @@
         "source_code": "https://github.com/tableau-mkt/insights-data-connector"
     },
     {
+        "name": "NoteTab",
+        "url": "https://github.com/CFMTech/NoteTab",
+        "author": "Brian Tribondeau",
+        "github_username": "btribonde",
+        "tags": ["v_0.9.3"],
+        "description": "Display in Tableau data from Jupyter notebooks ",
+        "source_code": "https://github.com/CFMTech/NoteTab"
+    },
+    {
         "name": "NPM Download Counts",
         "url": "http://jagreene.github.io/npm-wdc",
         "author": "Austin Greene",


### PR DESCRIPTION
NoteTab allows to display in Tableau data from Jupyter notebooks