### PR TITLE
Covid 19 India Dataset Connector

### DIFF
--- a/community/community_connectors.json
+++ b/community/community_connectors.json
@@ -955,7 +955,36 @@
         "tags": ["v_1.0"],
         "description": "Tableau Web Data Connector for fetching NY Times best sellers list",
         "source_code": "https://github.com/muthukumarsm/TableauWDC"
-    },    
+    }, 
+    {
+        "name": "India COVID 19 Data Connector - Patient data from crowdsourced DB",
+        "url": "https://muthukumarsm.github.io/covid19india/CovidIndia_Main.html",
+        "author": "Muthukumar S M (msm@tableau.com)",
+        "github_username": "muthukumarsm",
+        "tags": ["v_1.0"],
+        "description": "Tableau Web Data Connector for fetching COVID 19 India Dataset for all patients",
+        "source_code": "https://github.com/muthukumarsm/covid19india"
+    }, 
+
+{
+        "name": "India COVID 19 Data Connector - State-wise summary data",
+        "url": "https://muthukumarsm.github.io/covid19india/CovidIndia_Statewise.html",
+        "author": "Muthukumar S M (msm@tableau.com)",
+        "github_username": "muthukumarsm",
+        "tags": ["v_1.0"],
+        "description": "Tableau Web Data Connector for fetching Covid 19 India Dataset statewise - Summarization",
+        "source_code": "https://github.com/muthukumarsm/covid19india"
+    }, 
+
+{
+        "name": "India COVID 19 Data Connector - Daywise Summary data",
+        "url": "https://muthukumarsm.github.io/covid19india/CovidIndia_Daywise.html",
+        "author": "Muthukumar S M (msm@tableau.com)",
+        "github_username": "muthukumarsm",
+        "tags": ["v_1.0"],
+        "description": "Tableau Web Data Connector for fetching Covid 19 India Dataset Daily summary Active/Deceased/Recovered",
+        "source_code": "https://github.com/muthukumarsm/covid19india"
+    }, 
     {
     "name": "Dolar - Banco Central do Brasil",
     "url": "https://juracyamerico.github.io/Dolar-Conector-de-dados-da-Web/cotacoes_diarias_e_taxas_de_cambioV2.html",


### PR DESCRIPTION
There are three connectors being added. 
This is basically a volunteer-driven API (Unofficial) - The idea of adding this to Tableau repository is to show you the power of WDC API build framework to work on dynamic and real time data set and it is purely built out of self-interest. Though you can reach out to me regarding issues, Tableau would not be responsible for any issues encountered with this API as it is built out of my own interest.
1) Covid 19 India Main - Containing patient information pulled from crowdsourced database. If you would like to analyse the current situation in your location or aim at carrying out analysis on flattening the curve eventually, then this data set can help you!
2) Covid 19 India Statewise - Containing statewise representation in the form of summary for each state. This is useful to analyse the overall trend and individual measures being taken by each state across India towards recovery process and hospitalization ratios.
3) Covid 10 India Daywise - Contains daywise representation of active/hospitalized/recovered and deceased patient information.