### PR TITLE
update dpkg to open updated chrome package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 dist: trusty
 addons:
+  apt:
+    packages:
+    - dpkg
   chrome: stable
+
 language: node_js
 node_js:
 - node


### PR DESCRIPTION
This change addresses the issue mentioned here: https://travis-ci.community/t/you-can-no-longer-install-chrome-stable-on-trusty-machines/8521 

Current version of `dpkg` cannot process `.xz` file format. Updating dpkg allows installation of stable chrome on trusty.