### PR TITLE
Removed links to WDC v1 docs

### DIFF
--- a/docs/api_ref.md
+++ b/docs/api_ref.md
@@ -405,7 +405,7 @@ title: WDC API Reference
                 <div class="tsd-signature tsd-kind-icon">WebDataConnectorAPI: </div>
                 <div class="tsd-comment tsd-typography">
                     <div class="lead">
-                        <p>This API Reference contains all of the functions and objects for the WDC API version 2. For a version 1 reference, please consult this page: <a href="http://onlinehelp.Tableau.com/v9.3/api/wdc/en-us/help.htm#WDC/wdc_ref.htm%3FTocPath%3D_____9" target="_blank">WDC V1 Reference</a></p>
+                        <p>This API Reference contains all of the functions and objects for the WDC API version 2. WDC version 1 is no longer supported.</p>
                     </div>
                 </div>
                 <section class="tsd-panel tsd-member tsd-kind-interface tsd-parent-kind-module tsd-is-not-exported">

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,16 +8,14 @@ with JavaScript code that connects to web data (for example, by means of a REST 
 and passes the data to Tableau.
 
 <div class="alert alert-info">
-    <b>Note:</b> This site is for version 2.x of the WDC, which is compatible only with Tableau 10.0 and later. For
-    information about version 1 of the WDC for use with earlier versions of Tableau, see the archived <a href="http://onlinehelp.tableau.com/v9.3/api/wdc/en-us/help.htm" style="text-decoration:underline;">documentation</a>
-    and <a href="https://github.com/tableau/webdataconnector/releases/tag/v1.1.0" style="text-decoration:underline;">simulator</a>.  
+    <b>Note:</b> This site is for version 2.x of the WDC API, which is compatible only with Tableau 10.0 and later. Version 1 of the WDC API, used with earlier versions of Tableau, is no longer supported.  
 </div>
 
 -----
 
 **Upgrading from WDC version 1.x**
  
-If you have connectors that were created using WDC version 1.x, those connectors might not work in later versions of Tableau. If you want your connector to work in later versions of Tableau, or if you want to use the features available in version 2.x of the WDC, you will need to update the connector. For information about updating your connectors, see [Upgrading from WDC Version 1.x]({{ site.baseurl }}\docs\wdc_upgrade). For information about version compatibility, see [WDC Versions]({{ site.baseurl }}\docs\wdc_library_versions). 
+If you have connectors that were created using WDC version 1.x, those connectors might not work in later versions of Tableau. If you want your connector to work in later versions of Tableau, or if you want to use the features available in version 2.x of the WDC, you will need to update the connector. For information about updating your connectors, see [Upgrading from WDC Version 1.x]({{ site.baseurl }}\docs\wdc_upgrade). For information about version compatibility, see [WDC Versions]({{ site.baseurl }}\docs\wdc_library_versions).
 
 
 -----

--- a/docs/wdc_library_versions.md
+++ b/docs/wdc_library_versions.md
@@ -51,9 +51,6 @@ The connector requires at least version 'x.x' of the web data connector API.
 ```
 
 <div class="alert alert-info">
-    <b>Note:</b> This site is for version 2 of the WDC, and will only be compatible with Tableau 10.0 and later. For
-    information about version 1 of the WDC, see the archived <a href="http://onlinehelp.tableau.com/v9.3/api/wdc/en-us/help.htm" style="text-decoration:underline;">documentation</a>
-    and <a href="https://github.com/tableau/webdataconnector/releases/tag/v1.1.0" style="text-decoration:underline;">simulator</a>. 
-    
+    <b>Note:</b> This site is for version 2 of the WDC, and is only be compatible with Tableau 10.0 and later. Version 1 of the WDC is no longer supported.
 </div>
 If you are a developer, see [Upgrading from WDC Version 1.x]({{ site.baseurl }}\docs\wdc_upgrade) for information about migrating your WDC to version 2.


### PR DESCRIPTION
The WDC v1 docs are no longer available online. Removed links and changed text to indicate that v1 of the WDC is no longer supported. 