### PR TITLE
Fix typo

### DIFF
--- a/Examples/OAuthProxyExample/public/foursquare.js
+++ b/Examples/OAuthProxyExample/public/foursquare.js
@@ -38,7 +38,7 @@
   // This will redirect the user to a Foursquare login
   function doAuthRedirect() {
       var appId = config.clientId;
-      if (tableau.authPurpose === tableau.authPurposeEnum.ephemerel) {
+      if (tableau.authPurpose === tableau.authPurposeEnum.ephemeral) {
         appId = config.clientId;  // This should be Desktop
       } else if (tableau.authPurpose === tableau.authPurposeEnum.enduring) {
         appId = config.clientId; // This should be the Tableau Server appID

--- a/docs/wdc_oauth_tutorial.md
+++ b/docs/wdc_oauth_tutorial.md
@@ -497,7 +497,7 @@ First we'll add the code to enable the user to log in to Foursquare. Add this to
   // This will redirect the user to a foursquare login
   function doAuthRedirect() {
       var appId = config.clientId;
-      if (tableau.authPurpose === tableau.authPurposeEnum.ephemerel) {
+      if (tableau.authPurpose === tableau.authPurposeEnum.ephemeral) {
         appId = config.clientId;  // This should be Desktop
       } else if (tableau.authPurpose === tableau.authPurposeEnum.enduring) {
         appId = config.clientId; // This should be the Tableau Server appID
@@ -601,7 +601,7 @@ object.)
   // This will redirect the user to a foursquare login
   function doAuthRedirect() {
       var appId = config.clientId;
-      if (tableau.authPurpose === tableau.authPurposeEnum.ephemerel) {
+      if (tableau.authPurpose === tableau.authPurposeEnum.ephemeral) {
         appId = config.clientId;  // This should be Desktop
       } else if (tableau.authPurpose === tableau.authPurposeEnum.enduring) {
         appId = config.clientId; // This should be the Tableau Server appID
@@ -1248,7 +1248,7 @@ Versions]( {{ site.baseurl }}/docs/wdc_library_versions.html).
   // This will redirect the user to a foursquare login
   function doAuthRedirect() {
       var appId = config.clientId;
-      if (tableau.authPurpose === tableau.authPurposeEnum.ephemerel) {
+      if (tableau.authPurpose === tableau.authPurposeEnum.ephemeral) {
         appId = config.clientId;  // This should be Desktop
       } else if (tableau.authPurpose === tableau.authPurposeEnum.enduring) {
         appId = config.clientId; // This should be the Tableau Server appID


### PR DESCRIPTION
The two available values of `authPurposeEnum` are `enduring` and `ephemeral`.

This PR correct the typo by changing `ephemerel` to `ephemeral`.